### PR TITLE
Improve logging consistency

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -7,6 +7,8 @@ weight: 5
 
 This is a list of all errors that are coded (PB#_NUM_: ...) in Phonebook. The library encodes all of its errors in this format to give more context to the user when an error comes up.
 
+# General Error Codes
+
 |PB#Number|Title|Description|
 |:----|-|-|
 |PB#0001|**Provider undefined**|Phonebook requires a valid provider to be defined through the `PHONEBOOK_PROVIDER` environment variable. The list of available provider is [available here]({{< ref "/providers" >}}).|
@@ -14,3 +16,28 @@ This is a list of all errors that are coded (PB#_NUM_: ...) in Phonebook. The li
 |PB#0003|**Provider could not delete the DNS record**||
 |PB#0100|**Provider missing information**|Phonebook failed to initialized a client for the specified provider, more information can be found in the error message and in the provider's [section]({{< ref "/providers" >}}).|
 
+# Provider Specific Error Codes
+
+## Azure
+|Number|Title|Description|
+|:----|-|-|
+|PB-AZ-#0001|Azure Client ID Not Found|Phonebook failed to find a valid client ID from a secret or env-var for the azure provider|
+|PB-AZ-#0002|Azure Client Secret Not Found|Phonebook failed to find a valid client secret from a secret or env-var for the azure provider|
+|PB-AZ-#0003|Azure Tenant ID Not Found|Phonebook failed to find a valid tenant ID from a secret or env-var for the azure provider|
+|PB-AZ-#0004|Azure Subscription ID Not Found|Phonebook failed to find a valid subscription ID from a secret or env-var for the azure provider|
+|PB-AZ-#0005|Azure Zone Name Not Found|Phonebook failed to find a valid zone name from a secret or env-var for the azure provider|
+|PB-AZ-#0006|Azure Resource Group Not Found|Phonebook failed to find a valid resource group from a secret or env-var for the azure provider|
+|PB-AZ-#0007|Unable to Create Azure Credential|Phonebook was unable to create an Azure credential using the provided information|
+|PB-AZ-#0008|Unable to Create Azure DNS Client|Phonebook was unable to create an Azure DNS client using the provided information|
+|PB-AZ-#0009|Failed to Create Resource Record Set|Phonebook failed to create a resource record set for Azure DNS|
+|PB-AZ-#0010|Failed to Create Azure DNS Record|Phonebook failed to create an Azure DNS record|
+|PB-AZ-#0011|Failed to Delete Azure DNS Record|Phonebook failed to delete an Azure DNS record|
+|PB-AZ-#0012|CNAME Record Can Only Have One Target|Phonebook attempted to create a CNAME record with multiple targets, which is not allowed|
+|PB-AZ-#0013|Invalid MX Record|Phonebook encountered an invalid MX record format|
+|PB-AZ-#0014|Invalid SRV Record|Phonebook encountered an invalid SRV record format|
+|PB-AZ-#0015|Unsupported Record Type|Phonebook encountered an unsupported DNS record type for Azure DNS|
+
+## AWS
+
+
+## Cloudflare

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -41,3 +41,9 @@ This is a list of all errors that are coded (PB#_NUM_: ...) in Phonebook. The li
 
 
 ## Cloudflare
+|Number|Title|Description|
+|:----|-|-|
+|PB-CF-#0001|API Key Not Found|Phonebook failed to find a valid Cloudflare API key from a secret or env-var|
+|PB-CF-#0002|Zone ID Not Found|Phonebook failed to find a valid Cloudflare Zone ID from a secret or env-var|
+|PB-CF-#0003|Unable to Create Cloudflare Client|Phonebook was unable to create a Cloudflare client using the provided information|
+|PB-CF-#0004|Multiple Targets Not Supported|Phonebook attempted to create a DNS record with multiple targets, which is not supported by Cloudflare|

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -38,7 +38,13 @@ This is a list of all errors that are coded (PB#_NUM_: ...) in Phonebook. The li
 |PB-AZ-#0015|Unsupported Record Type|Phonebook encountered an unsupported DNS record type for Azure DNS|
 
 ## AWS
-
+|Number|Title|Description|
+|:----|-|-|
+|PB-AWS-#0001|Failed to Load AWS Configuration|Phonebook failed to load the AWS configuration|
+|PB-AWS-#0002|Zone ID Not Found|Phonebook failed to find a valid AWS Zone ID from a secret or env-var|
+|PB-AWS-#0003|Failed to Create DNS Record|Phonebook failed to create a DNS record in AWS Route 53|
+|PB-AWS-#0004|Failed to Delete DNS Record|Phonebook failed to delete a DNS record in AWS Route 53|
+|PB-AWS-#0005|Unsupported Record Type|Phonebook encountered an unsupported DNS record type for AWS Route 53|
 
 ## Cloudflare
 |Number|Title|Description|

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -31,11 +31,11 @@ func NewClient(ctx context.Context) (*r53, error) {
 	logger := log.FromContext(ctx)
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("PB-AWS-#0001: Failed to load AWS configuration -- %w", err)
 	}
 	zoneID, err := utils.RetrieveValueFromEnvOrFile(kAWSZoneID)
 	if err != nil {
-		return nil, fmt.Errorf("PB#0100: Zone ID not found -- %w", err)
+		return nil, fmt.Errorf("PB-AWS-#0002: Zone ID not found -- %w", err)
 	}
 
 	logger.Info("[Provider] AWS Configured", "Zone ID", zoneID)
@@ -58,7 +58,10 @@ func (c *r53) Create(ctx context.Context, record *phonebook.DNSRecord) error {
 	}
 
 	_, err := c.ChangeResourceRecordSets(ctx, &inputs)
-	return err
+	if err != nil {
+		return fmt.Errorf("PB-AWS-#0003: Failed to create DNS record -- %w", err)
+	}
+	return nil
 }
 
 func (c *r53) Delete(ctx context.Context, record *phonebook.DNSRecord) error {
@@ -73,7 +76,10 @@ func (c *r53) Delete(ctx context.Context, record *phonebook.DNSRecord) error {
 	}
 
 	_, err := c.ChangeResourceRecordSets(ctx, &inputs)
-	return err
+	if err != nil {
+		return fmt.Errorf("PB-AWS-#0004: Failed to delete DNS record -- %w", err)
+	}
+	return nil
 }
 
 // Convert a DNSRecord to a resourceRecordSet
@@ -132,8 +138,8 @@ func (c *r53) resourceRecordSet(ctx context.Context, record *phonebook.DNSRecord
 			}
 
 		default:
-			// For unsupported types, throw an error
-			log.FromContext(ctx).Error(fmt.Errorf("PB#4005: Unsupported record type"), "Record Type", record.Spec.RecordType)
+			// For unsupported types, log an error
+			log.FromContext(ctx).Error(fmt.Errorf("PB-AWS-#0005: Unsupported record type"), "Record Type", record.Spec.RecordType)
 		}
 	}
 

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewClient(t *testing.T) {
 	_, err := NewClient(context.TODO())
-	if !strings.HasPrefix(err.Error(), "PB#0100: Zone ID not found --") {
+	if !strings.HasPrefix(err.Error(), "PB-AWS-#0002: Zone ID not found --") {
 		t.Error("Client should require a Zone ID")
 	}
 

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -39,44 +39,44 @@ func NewClient(ctx context.Context) (*azureDNS, error) {
 
 	clientID, err := utils.RetrieveValueFromEnvOrFile(kAzureClientID)
 	if err != nil {
-		return nil, fmt.Errorf("PB#0104: Azure Client ID not found -- %w", err)
+		return nil, fmt.Errorf("PB-AZ-#0001: Azure Client ID not found -- %w", err)
 	}
 
 	clientSecret, err := utils.RetrieveValueFromEnvOrFile(kAzureClientSecret)
 	if err != nil {
-		return nil, fmt.Errorf("PB#0105: Azure Client Secret not found -- %w", err)
+		return nil, fmt.Errorf("PB-AZ-#0002: Azure Client Secret not found -- %w", err)
 	}
 
 	tenantID, err := utils.RetrieveValueFromEnvOrFile(kAzureTenantID)
 	if err != nil {
-		return nil, fmt.Errorf("PB#0106: Azure Tenant ID not found -- %w", err)
+		return nil, fmt.Errorf("PB-AZ-#0003: Azure Tenant ID not found -- %w", err)
 	}
 
 	subscriptionID, err := utils.RetrieveValueFromEnvOrFile(kAzureSubscriptionID)
 	if err != nil {
-		return nil, fmt.Errorf("PB#0101: Azure Subscription ID not found -- %w", err)
+		return nil, fmt.Errorf("PB-AZ-#0004: Azure Subscription ID not found -- %w", err)
 	}
 
 	zoneName, err := utils.RetrieveValueFromEnvOrFile(kAzureZoneName)
 	if err != nil {
-		return nil, fmt.Errorf("PB#0102: Azure Zone Name not found -- %w", err)
+		return nil, fmt.Errorf("PB-AZ-#0005: Azure Zone Name not found -- %w", err)
 	}
 
 	resourceGroup, err := utils.RetrieveValueFromEnvOrFile(kAzureResourceGroup)
 	if err != nil {
-		return nil, fmt.Errorf("PB#0103: Azure Resource Group not found -- %w", err)
+		return nil, fmt.Errorf("PB-AZ-#0006: Azure Resource Group not found -- %w", err)
 	}
 
 	// Create the credential
 	credential, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create Azure credential: %w", err)
+		return nil, fmt.Errorf("PB-AZ-#0007: Unable to create Azure credential: %w", err)
 	}
 
 	// Initialize the DNS client
 	dnsClient, err := armdns.NewRecordSetsClient(subscriptionID, credential, &arm.ClientOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to create Azure DNS client: %w", err)
+		return nil, fmt.Errorf("PB-AZ-#0008: Unable to create Azure DNS client: %w", err)
 	}
 
 	logger.Info("[Provider] Azure Configured", "Zone Name", zoneName, "Resource Group", resourceGroup)
@@ -92,11 +92,11 @@ func NewClient(ctx context.Context) (*azureDNS, error) {
 func (c *azureDNS) Create(ctx context.Context, record *phonebook.DNSRecord) error {
 	params, err := c.resourceRecordSet(ctx, record)
 	if err != nil {
-		return fmt.Errorf("failed to create resource record set: %w", err)
+		return fmt.Errorf("PB-AZ-#0009: Failed to create resource record set: %w", err)
 	}
 	response, err := c.recordSetsClient.CreateOrUpdate(ctx, c.resourceGroup, c.zoneName, record.Spec.Name, armdns.RecordType(record.Spec.RecordType), params, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create Azure DNS record: %w", err)
+		return fmt.Errorf("PB-AZ-#0010: Failed to create Azure DNS record: %w", err)
 	}
 
 	record.Status.Provider = "Azure"
@@ -111,7 +111,7 @@ func (c *azureDNS) Create(ctx context.Context, record *phonebook.DNSRecord) erro
 func (c *azureDNS) Delete(ctx context.Context, record *phonebook.DNSRecord) error {
 	_, err := c.recordSetsClient.Delete(ctx, c.resourceGroup, c.zoneName, record.Spec.Name, armdns.RecordType(record.Spec.RecordType), nil)
 	if err != nil {
-		return fmt.Errorf("failed to delete Azure DNS record: %w", err)
+		return fmt.Errorf("PB-AZ-#0011: failed to delete Azure DNS record: %w", err)
 	}
 
 	record.Status.Provider = "Azure"
@@ -156,8 +156,8 @@ func (c *azureDNS) resourceRecordSet(ctx context.Context, record *phonebook.DNSR
 		// CNAME can only have one target
 		// If Targets is more than one, throw an error
 		if len(record.Spec.Targets) > 1 {
-			err := fmt.Errorf("CNAME record can only have one target")
-			log.FromContext(ctx).Error(err, "CNAME record can only have one target")
+			err := fmt.Errorf("PB-AZ-#0012: CNAME record can only have one target")
+			log.FromContext(ctx).Error(err, "PB-AZ-#0012: CNAME record can only have one target")
 			return armdns.RecordSet{}, err
 		}
 
@@ -170,8 +170,8 @@ func (c *azureDNS) resourceRecordSet(ctx context.Context, record *phonebook.DNSR
 		for i, target := range record.Spec.Targets {
 			parts := strings.SplitN(target, " ", 2)
 			if len(parts) != 2 {
-				err := fmt.Errorf("invalid MX record: %s", target)
-				log.FromContext(ctx).Error(err, "Invalid MX record")
+				err := fmt.Errorf("PB-AZ-#0013: invalid MX record: %s", target)
+				log.FromContext(ctx).Error(err, "PB-AZ-#0013: Invalid MX record")
 				return armdns.RecordSet{}, err
 			}
 			mxRecords[i] = &armdns.MxRecord{
@@ -193,8 +193,8 @@ func (c *azureDNS) resourceRecordSet(ctx context.Context, record *phonebook.DNSR
 		for i, target := range record.Spec.Targets {
 			parts := strings.Split(target, " ")
 			if len(parts) != 4 {
-				err := fmt.Errorf("invalid SRV record: %s", target)
-				log.FromContext(ctx).Error(err, "Invalid SRV record")
+				err := fmt.Errorf("PB-AZ-#0014: Invalid SRV record: %s", target)
+				log.FromContext(ctx).Error(err, "PB-AZ-#0014: Invalid SRV record")
 				return armdns.RecordSet{}, err
 			}
 			srvRecords[i] = &armdns.SrvRecord{
@@ -208,8 +208,8 @@ func (c *azureDNS) resourceRecordSet(ctx context.Context, record *phonebook.DNSR
 
 	default:
 		// Unsupported record type and return an error
-		err := fmt.Errorf("unsupported record type: %s", record.Spec.RecordType)
-		log.FromContext(ctx).Error(err, "Unsupported record type")
+		err := fmt.Errorf("PB-AZ-#0015: Unsupported record type: %s", record.Spec.RecordType)
+		log.FromContext(ctx).Error(err, "PB-AZ-#0015: Unsupported record type")
 	}
 
 	return params, nil

--- a/pkg/cloudflare/client_test.go
+++ b/pkg/cloudflare/client_test.go
@@ -71,7 +71,7 @@ func (c *cft) Delete(ctx context.Context, record *phonebook.DNSRecord) error {
 func TestNewClient(t *testing.T) {
 	// Test missing API Key
 	_, err := NewClient(context.TODO())
-	if err == nil || !strings.HasPrefix(err.Error(), "PB#0100: API Key not found --") {
+	if err == nil || !strings.HasPrefix(err.Error(), "PB-CF-#0001: API Key not found --") {
 		t.Error("Expected error for missing API Key")
 	}
 
@@ -80,7 +80,7 @@ func TestNewClient(t *testing.T) {
 
 	// Test missing Zone ID
 	_, err = NewClient(context.TODO())
-	if err == nil || !strings.HasPrefix(err.Error(), "PB#0100: Zone ID not found --") {
+	if err == nil || !strings.HasPrefix(err.Error(), "PB-CF-#0002: Zone ID not found --") {
 		t.Error("Expected error for missing Zone ID")
 	}
 


### PR DESCRIPTION
In reference to Issue #6 

Please feel free to reject if you disagree with my idea/opinion!

I've updated the various error messages we've got around, I'd not fully clocked your numbering scheme when I added the azure provider and had missed quite a few,

I've worked on projects before with a sequential numbering system which is great, until you use 101 in aws, and 102 in azure and I've found it can get a bit messy, so the prefix with the provider in it IMHO solves that problem, 

Hopefully you find this helpful and sets things up to be a bit easier to maintain as the project grows

Cheers
Rob