### PR TITLE
Release 0.3.3

### DIFF
--- a/charts/main/Chart.yaml
+++ b/charts/main/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.2
+appVersion: 0.3.3


### PR DESCRIPTION
I screwed up some versioning debugging helm charts and now that I want to release a new version, I feel like I should just reset helm/application version to the same value and clean my mess.

So, I'll bump app version to 0.3.3 so that the next helm release will match the app version.

This is just to avoid confusion, specially with the way the github action packages the helm charts. I'll probably have to spend some time eventually to try and fix the github action to just reuse releases that I cut, but I'm not there yet.

Once this merges, I'll create a new release & tag so that github action picks it up and release the new chart. 